### PR TITLE
Adjust AppTheme card theme configuration

### DIFF
--- a/lib/src/theme/app_theme.dart
+++ b/lib/src/theme/app_theme.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  const AppTheme._();
+
+  static final ThemeData light = _buildTheme(Brightness.light);
+  static final ThemeData dark = _buildTheme(Brightness.dark);
+
+  static ThemeData _buildTheme(Brightness brightness) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: Colors.deepPurple,
+      brightness: brightness,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      cardTheme: const CardTheme(margin: EdgeInsets.zero),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- build light and dark ThemeData instances through a shared helper that applies the zero-margin CardTheme

## Testing
- flutter analyze *(fails: `flutter` not installed in container)*
- flutter test *(fails: `flutter` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd1b8fea08320bb7aeee69c49a882