### PR TITLE
Use shared theme helper for seed color

### DIFF
--- a/lib/src/theme/app_theme.dart
+++ b/lib/src/theme/app_theme.dart
@@ -1,24 +1,17 @@
 import 'package:flutter/material.dart';
 
 class AppTheme {
-  static ThemeData get light => ThemeData(
-        brightness: Brightness.light,
+  static ThemeData get light => _buildTheme(Brightness.light);
+
+  static ThemeData get dark => _buildTheme(Brightness.dark);
+
+  static ThemeData _buildTheme(Brightness brightness) => ThemeData(
+        brightness: brightness,
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(
-          brightness: Brightness.light,
+          brightness: brightness,
           seedColor: const Color(0xFF0066FF),
         ),
         cardTheme: const CardTheme(margin: EdgeInsets.zero),
       );
-
-  static ThemeData get dark => ThemeData(
-        brightness: Brightness.dark,
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          brightness: Brightness.dark,
-          seedColor: const Color(0xFF0066FF),
-        ),
-        cardTheme: const CardTheme(margin: EdgeInsets.zero),
-      );
-
 }


### PR DESCRIPTION
## Summary
- reuse a private helper to build light and dark themes
- ensure the shared helper seeds the color scheme with const Color(0xFF0066FF)

## Testing
- not run (dart command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdd7e066308320b569314752a63a3f